### PR TITLE
Added support for VS2015

### DIFF
--- a/ExceptionBreaker/source.extension.vsixmanifest
+++ b/ExceptionBreaker/source.extension.vsixmanifest
@@ -20,6 +20,9 @@ It is available through both `Debug` toolbar and `Debug` top level menu.</Descri
       <VisualStudio Version="12.0">
         <Edition>Pro</Edition>
       </VisualStudio>
+      <VisualStudio Version="14.0">
+        <Edition>Pro</Edition>
+      </VisualStudio>
     </SupportedProducts>
     <SupportedFrameworkRuntimeEdition MinVersion="4.0" />
   </Identifier>


### PR DESCRIPTION
For some reason, the github web UI changes indentation so it looks like the entire file was modified. I only added this:

```xml
<VisualStudio Version="14.0">
    <Edition>Pro</Edition>
</VisualStudio>
```